### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
 	"description": "Import volumes from cloud (Google Cloud Storage, Amazon S3, Microsoft Azure, ...)",
 	"categories": ["import", "volumes"],
 	"docker_image": "supervisely/import-export:6.73.564",
-    "instance_version": "6.12.23",
+    "instance_version": "6.15.60",
 	"icon": "https://user-images.githubusercontent.com/48913536/211333862-55f1960e-2e75-475b-9536-dd018db8732c.png",
 	"poster": "https://user-images.githubusercontent.com/48913536/211368662-fe22dbe0-0542-4694-b1b9-8fdcb68216a4.png",
 	"entrypoint": "python -m uvicorn src.main:app --host 0.0.0.0 --port 8000",

--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
 	"version": "2.0.0",
 	"description": "Import volumes from cloud (Google Cloud Storage, Amazon S3, Microsoft Azure, ...)",
 	"categories": ["import", "volumes"],
-	"docker_image": "supervisely/import-export:6.73.291",
+	"docker_image": "supervisely/import-export:6.73.564",
     "instance_version": "6.12.23",
 	"icon": "https://user-images.githubusercontent.com/48913536/211333862-55f1960e-2e75-475b-9536-dd018db8732c.png",
 	"poster": "https://user-images.githubusercontent.com/48913536/211368662-fe22dbe0-0542-4694-b1b9-8fdcb68216a4.png",

--- a/config.json
+++ b/config.json
@@ -1,13 +1,16 @@
 {
-	"name": "Import volumes from cloud storage",
-	"type": "app",
-	"version": "2.0.0",
-	"description": "Import volumes from cloud (Google Cloud Storage, Amazon S3, Microsoft Azure, ...)",
-	"categories": ["import", "volumes"],
-	"docker_image": "supervisely/import-export:6.73.564",
-    "instance_version": "6.15.60",
-	"icon": "https://user-images.githubusercontent.com/48913536/211333862-55f1960e-2e75-475b-9536-dd018db8732c.png",
-	"poster": "https://user-images.githubusercontent.com/48913536/211368662-fe22dbe0-0542-4694-b1b9-8fdcb68216a4.png",
-	"entrypoint": "python -m uvicorn src.main:app --host 0.0.0.0 --port 8000",
-	"port": 8000
+  "name": "Import volumes from cloud storage",
+  "type": "app",
+  "version": "2.0.0",
+  "description": "Import volumes from cloud (Google Cloud Storage, Amazon S3, Microsoft Azure, ...)",
+  "categories": [
+    "import",
+    "volumes"
+  ],
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "instance_version": "6.15.60",
+  "icon": "https://user-images.githubusercontent.com/48913536/211333862-55f1960e-2e75-475b-9536-dd018db8732c.png",
+  "poster": "https://user-images.githubusercontent.com/48913536/211368662-fe22dbe0-0542-4694-b1b9-8fdcb68216a4.png",
+  "entrypoint": "python -m uvicorn src.main:app --host 0.0.0.0 --port 8000",
+  "port": 8000
 }

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.291
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
